### PR TITLE
Reset when save is deleted

### DIFF
--- a/chantsofsennaar.asl
+++ b/chantsofsennaar.asl
@@ -158,7 +158,10 @@ update
 reset
 {
     // Check if player is on title screen.
-    return current.currentPlacePtr == current.titleScreenPtr;
+    return current.currentPlacePtr == current.titleScreenPtr && 
+        !(vars.oldLevelId == 0 && vars.oldPlaceId == 0) && 
+        vars.currentLevelId == 0 &&
+        vars.currentPlaceId == 0;
 }
 
 onReset


### PR DESCRIPTION
Reset condition is:
- User is on title screen
- Detect current game save id, and check if level/place id went to 0/0

Technically this won't reset if you reset on the first screen, or go back to the first screen and then try to reset. I think these are rare enough that we don't have to worry about them.